### PR TITLE
Remove dependency on `unstable-list-lib`

### DIFF
--- a/check-sexp-equal.scrbl
+++ b/check-sexp-equal.scrbl
@@ -2,8 +2,7 @@
 
 @(require (for-label racket "main.rkt"))
 @(require scribble/base scribble/manual scribble/eval
-          (for-label racket/base racket/dict syntax/id-table racket/contract
-                     unstable/list))
+          (for-label racket/base racket/dict syntax/id-table racket/contract))
 
 @title{check-sexp-equal}
 

--- a/info.rkt
+++ b/info.rkt
@@ -8,6 +8,6 @@
                "base"
                "rackunit-lib"))
 
-(define build-deps '("scribble-lib"))
+(define build-deps '("scribble-lib" "racket-doc"))
 
 (define scribblings '(("check-sexp-equal.scrbl" ())))

--- a/info.rkt
+++ b/info.rkt
@@ -8,6 +8,6 @@
                "base"
                "rackunit-lib"))
 
-(define build-deps '("scribble-lib" "unstable-list-lib"))
+(define build-deps '("scribble-lib"))
 
 (define scribblings '(("check-sexp-equal.scrbl" ())))


### PR DESCRIPTION
Most of the functionality of that package will be moved into the core libraries by Racket PR #972, and `unstable-list-lib` will be removed from the main distribution.

This package depends, but does not actually use `unstable-list-lib` so this change is compatible with Racket 6.2 and prior.
